### PR TITLE
IPv6.php comment typos

### DIFF
--- a/Net/IPv6.php
+++ b/Net/IPv6.php
@@ -611,7 +611,7 @@ class Net_IPv6
 
             } else {                          // xxx::xxx
 
-                $fill = str_repeat(':0:', 6-$c2-$c1);
+                $fill = str_repeat(':0:', max(1, 6-$c2-$c1));
                 $uip  = str_replace('::', $fill, $uip);
                 $uip  = str_replace('::', ':', $uip);
 


### PR DESCRIPTION
While looking at this code (used in pfSense) I noticed a few typos in the comments, thought it worthwhile tidying them up for a future release.
