### PR TITLE
fix Net_IPv6::compress() to properly handle all-zeros address

### DIFF
--- a/Net/IPv6.php
+++ b/Net/IPv6.php
@@ -744,6 +744,12 @@ class Net_IPv6
         $cip = preg_replace('/((^:)|(:$))/', '', $cip);
         $cip = preg_replace('/((^:)|(:$))/', '::', $cip);
 
+        if (empty($cip)) {
+
+            $cip = "::";
+
+        }
+
         if ('' != $netmask) {
 
             $cip = $cip.'/'.$netmask;

--- a/tests/Net/Ipv6/Test/BugsTest.php
+++ b/tests/Net/Ipv6/Test/BugsTest.php
@@ -188,4 +188,20 @@ class Net_Ipv6_Test_BugsTest extends Net_Ipv6_Test_BaseTest
     {
         $this->assertFalse($this->ip->checkIPv6("2345::1/-1"));
     }
+
+    /**
+     * Test covers bugfix in pear/Net_IPv6#10.
+     *
+     * @return void
+     * @link https://github.com/pear/Net_IPv6/pull/10
+     */
+    public function testPR10_compressAllZeros()
+    {
+        $testip = "0:0:0:0:0:0:0:0";
+        $is = $this->ip->compress($testip);
+        $this->assertEquals("::", $is);
+        $testip = "::";
+        $is = $this->ip->compress($testip);
+        $this->assertEquals("::", $is);
+    }
 }


### PR DESCRIPTION
The existing implementation of Net_IPv6::compress produces an empty
string when compressing the all-zeros ("::") address; fix this by
checking for empty return values and replacing them with "::".