### PR TITLE
Handle call to SplitV64 with IPv4-only string

### DIFF
--- a/Net/IPv6.php
+++ b/Net/IPv6.php
@@ -843,6 +843,11 @@ class Net_IPv6
         if (strstr($ip, '.')) {
 
             $pos      = strrpos($ip, ':');
+
+            if ($pos === false) {
+                return array("", $ip);
+            }
+
             $ip{$pos} = '_';
             $ipPart   = explode('_', $ip);
 


### PR DESCRIPTION
For example:

```
var_dump(Net_IPv6::SplitV64("13.1.68.3"));
array(2) {
[0] =>
string(0) ""
[1] =>
string(8) "3.1.68.3"
}
```

Notice that the "1" in "13" has disappeared from the front of the
string.
Fixed by this change.
Note that SplitV64 does no validation of the supposed IPv6 and IPv4
parts - that is OK, it is up to the caller to validate the parts (before
or after calling SplitV64) using other functions.
