### PR TITLE
Handle invalid colon at start or end

### DIFF
--- a/Net/IPv6.php
+++ b/Net/IPv6.php
@@ -896,7 +896,7 @@ class Net_IPv6
 
             for ($i = 0; $i < count($ipv6); $i++) {
 
-                if(4 < strlen($ipv6[$i])) {
+                if ((4 < strlen($ipv6[$i])) || (0 == strlen($ipv6[$i]))) {
                     
                     return false;
 


### PR DESCRIPTION
Calls like Net_IPv6::checkIPv6(":1:2:3:4:5:6:7:8:") return true, unfortunately. The blank
element at the start or finish passes through the following code without
incrementing $count. Thus $count comes out with 8, even though there are
also empty elements at the start or end making a total of 10 elements.
Strings like "1:2:3::6:7:8" work because checkIPv6 calls SplitV64,
which does uncompress, turning the string into "1:2:3:0:0:6:7:8" - so
when processing the uncompressed address string we really do want to
make sure that every element is a non-zero length.
