### PR TITLE
Fix matching of chars in IPv6 address segments

### DIFF
--- a/Net/IPv6.php
+++ b/Net/IPv6.php
@@ -889,7 +889,7 @@ class Net_IPv6
             $ipv6 = explode(':', $ipPart[0]);
 
             foreach($ipv6 as $element) { // made a validate precheck
-                if(!preg_match('/[0-9a-fA-F]*/', $element)) {
+                if(!preg_match('/^[0-9a-fA-F]*$/', $element)) {
                     return false;
                 }
             }


### PR DESCRIPTION
The existing regex here is wrong, it matches 0 or more of the hex digits but then there can be other rubbish in the string, in fact anything at all! It matches "az", "z", "qwerty" and so on. So the "return false" inside this "if" never happens.
In most cases the later code catches problems, because it converts the string from hex to decimal (and things like "z" end up as decimal 0), then it does some back-conversion of the answer to hex and realizes something is different and so does not count the entry as one of the needed 8 valid segments of the IPv6 address.
This goes wrong if the user supplies a string with 8 valid IPv6 hex pieces and 1 or more extra invalid ones anywhere in the list. In that case the code finds 8 good chunks and thinks that all is well.
Try using strings like:
"1:2:3:4:5:6:7:z:a"
"1:2:3:xy:4:5:6:7:8"
"gh:1:2:3:xy:4:5:6:7:8"
"1:2:3:xy:4:5:6:7:8:qw"
This change makes this initial validity check on the characters actually work, so it avoids the later code having to deal with that at all.
